### PR TITLE
Fix github authorize bug

### DIFF
--- a/github/authorizations_service.go
+++ b/github/authorizations_service.go
@@ -14,6 +14,9 @@ type authorizationsService struct {
 
 func (a *authorizationsService) CreateToken(ctx context.Context) (string, error) {
 	note, err := a.getUniqueNote(ctx, "hlb")
+	if err != nil {
+		return "", err
+	}
 
 	authReq := &github.AuthorizationRequest{
 		Note:   github.String(note),
@@ -21,19 +24,37 @@ func (a *authorizationsService) CreateToken(ctx context.Context) (string, error)
 	}
 
 	auth, _, err := a.raw.Create(ctx, authReq)
-	return *auth.Token, errors.Wrap(err, "Failed to get authorizations by raw client in github.Client.CreateToken")
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get authorizations by raw client in github.Client.CreateToken")
+	}
+
+	return *auth.Token, nil
 }
 
 func (a *authorizationsService) getUniqueNote(ctx context.Context, orgNote string) (string, error) {
-	auths, _, err := a.raw.List(ctx, nil)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to get authorizations by raw client in github.Client.GetPullRequestsURL")
+	opt := &github.ListOptions{
+		PerPage: 100,
+	}
+
+	var allAuths []*github.Authorization
+	for {
+		auths, resp, err := a.raw.List(ctx, opt)
+		if err != nil {
+			return "", errors.Wrap(err, "Failed to get authorizations by raw client in github.Client.GetPullRequestsURL")
+		}
+
+		allAuths = append(allAuths, auths...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 
 	cnt := 1
 	note := orgNote
 	for {
-		if !hasAuthNote(auths, note) {
+		if !hasAuthNote(allAuths, note) {
 			return note, nil
 		}
 		cnt++


### PR DESCRIPTION
If github personal access tokens num exceeds 20, failure to add new access token.
This problem is due to the fact that authorization is listed up to 20 only by default.
This commit changed list option for increase PerPage to 100, and fetch all token by pagination.